### PR TITLE
support variadic function parameters in injector

### DIFF
--- a/src/Reflection/ParameterInspector.php
+++ b/src/Reflection/ParameterInspector.php
@@ -90,6 +90,9 @@ class ParameterInspector
                 if ($parameter->isDefaultValueAvailable()) {
                     $parameterSignature['default'] = $parameter->getDefaultValue();
                 }
+                if ($parameter->isVariadic()) {
+                    $parameterSignature['variadic'] = true;
+                }
 
                 $methodSignature[] = $parameterSignature;
             }

--- a/tests/Dummy/DummySimpleConstructor.php
+++ b/tests/Dummy/DummySimpleConstructor.php
@@ -26,19 +26,28 @@ class DummySimpleConstructor
     private $age;
 
     /**
+     * @var string[]
+     */
+    private $args;
+
+    /**
      * DummySimpleConstructor constructor.
      * @param ServiceCacheInterface $cache
      * @param DummyDependency $dummyDependency
      * @param string $name
      * @param int $age
+     * @param string ...$args
      */
-    public function __construct(ServiceCacheInterface $cache, DummyDependency $dummyDependency, $name, $age = 25)
+    public function __construct(ServiceCacheInterface $cache, DummyDependency $dummyDependency, $name, $age = 25, string ...$args)
     {
 
         $this->cache = $cache;
         $this->dummyDependency = $dummyDependency;
         $this->name = $name;
         $this->age = $age;
+        foreach ($args as $arg) {
+            $this->args[] = $arg;
+        }
     }
 
     /**
@@ -71,5 +80,13 @@ class DummySimpleConstructor
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getArgs()
+    {
+        return $this->args;
     }
 }

--- a/tests/Dummy/DummyString.php
+++ b/tests/Dummy/DummyString.php
@@ -1,0 +1,26 @@
+<?php
+namespace Tests\Dummy;
+
+class DummyString
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $value
+     */
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function value()
+    {
+        return $this->value;
+    }
+}

--- a/tests/Dummy/DummyVariadicConstructor.php
+++ b/tests/Dummy/DummyVariadicConstructor.php
@@ -1,0 +1,28 @@
+<?php
+namespace Tests\Dummy;
+
+class DummyVariadicConstructor
+{
+    /**
+     * @var DummyString[]
+     */
+    private $args;
+
+    /**
+     * @param DummyString ...$args
+     */
+    public function __construct(DummyString ...$args)
+    {
+        foreach ($args as $arg) {
+            $this->args[] = $arg;
+        }
+    }
+
+    /**
+     * @return DummyString[]
+     */
+    public function getArgs()
+    {
+        return $this->args;
+    }
+}

--- a/tests/Reflection/ParameterInspectorTest.php
+++ b/tests/Reflection/ParameterInspectorTest.php
@@ -92,6 +92,16 @@ class ParameterInspectorTest extends TestCase
         $this->assertEquals([], $signature);
     }
 
+    public function testGetSignatureVariadicParameter()
+    {
+        $ref = new ParameterInspector($this->cache->reveal());
+        $signature = $ref->getSignatureByClassName(self::class, "example4");
+        $this->assertEquals(
+            ["name" => "args", "variadic" => true],
+            $signature[0]
+        );
+    }
+
     public function testCacheHit()
     {
         $cacheSignature = [
@@ -129,6 +139,15 @@ class ParameterInspectorTest extends TestCase
      * @return void
      */
     private function example3()
+    {
+    }
+
+    /**
+     * THIS METHOD IS INSPECTED AS PART OF THIS TEST. DO NOT REMOVE
+     * No parameters
+     * @return void
+     */
+    private function example4(string ...$args)
     {
     }
 }


### PR DESCRIPTION
#### What?
To support variadic function parameters in injector, so that 
```
class Foo 
{
    public function __construct(...$args) {}
}
```

can be injected with
```
$injector->create(
  Foo::class,
  [
      'args' => [1, 2, 3],
  ]
);
```

#### Tickets / Documentation

This is for https://jira.bigcommerce.com/browse/ORDERS-1347. 