### PR TITLE
fix circleci support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,9 @@ workflows:
   full:
     jobs:
       - php/phpunit-tests:
-          configuration: "phpunit.xml.dist"
+          e:
+            name: php/php
+            php-version: <<matrix.php-version>>
           matrix:
             parameters:
               php-version: [ "7.4-fpm", "8.0-fpm" ]

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "psr/container": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.6 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+    "phpunit/phpunit": "^5.6 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+    "phpspec/prophecy-phpunit": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ec9ef6383d055060a35697c8c5db3da",
+    "content-hash": "1ba7deaab585771054aaabe953d82c6c",
     "packages": [
         {
             "name": "ocramius/package-versions",
@@ -823,6 +823,54 @@
                 "stub"
             ],
             "time": "2020-09-29T09:10:42+00:00"
+        },
+        {
+            "name": "phpspec/prophecy-phpunit",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy-phpunit.git",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8",
+                "phpspec/prophecy": "^1.3",
+                "phpunit/phpunit": "^9.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\PhpUnit\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                }
+            ],
+            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
+            "homepage": "http://phpspec.net",
+            "keywords": [
+                "phpunit",
+                "prophecy"
+            ],
+            "time": "2020-07-09T08:33:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/tests/InjectorServiceProviderTest.php
+++ b/tests/InjectorServiceProviderTest.php
@@ -6,6 +6,7 @@ use Bigcommerce\Injector\ServiceProvider\BindingClosureFactory;
 use PHPUnit\Framework\TestCase;
 use Pimple\Container;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
 /**
@@ -14,6 +15,8 @@ use Prophecy\Prophecy\ObjectProphecy;
  */
 class InjectorServiceProviderTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var Injector|ObjectProphecy */
     private $injector;
 

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -6,6 +6,7 @@ use Bigcommerce\Injector\Exception\InjectorInvocationException;
 use Bigcommerce\Injector\Injector;
 use Bigcommerce\Injector\Reflection\ParameterInspector;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Tests\Dummy\DummyDependency;
@@ -23,6 +24,8 @@ use TypeError;
  */
 class InjectorTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ContainerInterface|ObjectProphecy
      */
@@ -56,7 +59,7 @@ class InjectorTest extends TestCase
     public function testCreatePrivateConstructor()
     {
         $this->expectException(InjectorInvocationException::class);
-        $this->expectExceptionMessageRegExp(
+        $this->expectExceptionMessageMatches(
             "/constructor isn't public/ims"
         );
         $injector = new Injector($this->container->reveal(), $this->inspector->reveal());
@@ -256,7 +259,7 @@ class InjectorTest extends TestCase
             'missing parameter \'\$dependency \[' . addslashes(DummySubDependency::class) . '\]\'',
             'Called when creating ' . addslashes(DummySimpleConstructor::class)
         ];
-        $this->expectExceptionMessageRegExp("/.*?" . implode(".*?", $messageContains) . ".*?/ims");
+        $this->expectExceptionMessageMatches("/.*?" . implode(".*?", $messageContains) . ".*?/ims");
         $cacheMock = $this->prophesize(ServiceCacheInterface::class)->reveal();
 
         $this->mockDummySimpleSignature();
@@ -278,7 +281,7 @@ class InjectorTest extends TestCase
     public function testCreateMissingParameter()
     {
         $this->expectException(InjectorInvocationException::class);
-        $this->expectExceptionMessageRegExp(
+        $this->expectExceptionMessageMatches(
             '/missing parameter \'\$cache \[' . addslashes(ServiceCacheInterface::class) . '\]\'/ims'
         );
         $this->mockDummySimpleSignature();
@@ -333,7 +336,7 @@ class InjectorTest extends TestCase
             'Can\'t invoke method ' . addslashes(DummyNoConstructor::class) . '::setAge',
             'missing parameter \'\$age\''
         ];
-        $this->expectExceptionMessageRegExp("/" . implode(".*?", $messageContains) . "/ims");
+        $this->expectExceptionMessageMatches("/" . implode(".*?", $messageContains) . "/ims");
         $this->mockInspectorSignatureByClassName(
             DummyNoConstructor::class,
             "setAge",
@@ -357,7 +360,7 @@ class InjectorTest extends TestCase
         $messageContains = [
             'Failed to invoke ' . addslashes(DummyNoConstructor::class) . '::setName - method doesn\'t exist.'
         ];
-        $this->expectExceptionMessageRegExp("/" . implode(".*?", $messageContains) . "/ims");
+        $this->expectExceptionMessageMatches("/" . implode(".*?", $messageContains) . "/ims");
         $this->inspector->getSignatureByClassName(DummyNoConstructor::class, "setName")->willThrow(
             new \ReflectionException("bad stuff")
         );

--- a/tests/Reflection/ParameterInspectorTest.php
+++ b/tests/Reflection/ParameterInspectorTest.php
@@ -5,6 +5,7 @@ use Bigcommerce\Injector\Cache\ArrayServiceCache;
 use Bigcommerce\Injector\Cache\ServiceCacheInterface;
 use Bigcommerce\Injector\Reflection\ParameterInspector;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Tests\Dummy\MagicCallDummy;
 
@@ -14,6 +15,8 @@ use Tests\Dummy\MagicCallDummy;
  */
 class ParameterInspectorTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ObjectProphecy|ServiceCacheInterface */
     private $cache;
 

--- a/tests/ServiceProvider/BindingClosureFactoryTest.php
+++ b/tests/ServiceProvider/BindingClosureFactoryTest.php
@@ -6,6 +6,7 @@ use Bigcommerce\Injector\Injector;
 use Bigcommerce\Injector\ServiceProvider\BindingClosureFactory;
 use PHPUnit\Framework\TestCase;
 use Pimple\Container;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\Proxy\ValueHolderInterface;
@@ -17,6 +18,8 @@ use ProxyManager\Proxy\VirtualProxyInterface;
  */
 class BindingClosureFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var Injector|ObjectProphecy */
     private $injector;
 


### PR DESCRIPTION
#### What?

Fix circleci according to orb

Added `phpspec/prophecy-phpunit` to avoid deprecation warnings in tests

Replace removed `expectExceptionMessageRegExp` function 