### PR TITLE
Cache constructor signatures in serviceCache

### DIFF
--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -31,12 +31,6 @@ parameters:
 			path: ../src/Injector.php
 
 		-
-			message: '#^Method Bigcommerce\\Injector\\Injector\:\:buildParameterArray\(\) has InvalidArgumentException in PHPDoc @throws tag but it''s not thrown\.$#'
-			identifier: throws.unusedType
-			count: 1
-			path: ../src/Injector.php
-
-		-
 			message: '#^Method Bigcommerce\\Injector\\Injector\:\:buildParameterArray\(\) has parameter \$methodSignature with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -198,7 +198,6 @@ class Injector implements InjectorInterface
      * @return array
      * @throws InjectorInvocationException
      * @throws MissingRequiredParameterException
-     * @throws InvalidArgumentException
      * @throws ReflectionException
      */
     private function buildParameterArray($methodSignature, $providedParameters)

--- a/src/Reflection/CachingClassInspector.php
+++ b/src/Reflection/CachingClassInspector.php
@@ -109,8 +109,19 @@ class CachingClassInspector implements ClassInspectorInterface
         if (isset($this->constructorCache[$class])) {
             return $this->constructorCache[$class][0];
         }
+
+        $key = "$class::__construct::callable_signature";
+        if ($this->serviceCache->has($key)) {
+            $result = $this->serviceCache->get($key);
+            $this->constructorCache[$class] = [$result];
+            return $result;
+        }
+
         $result = $this->classInspector->getCallableConstructorSignature($class);
         $this->constructorCache[$class] = [$result];
+        if (is_array($result)) {
+            $this->serviceCache->set($key, $result);
+        }
         return $result;
     }
 

--- a/tests/Reflection/CachingClassInspectorTest.php
+++ b/tests/Reflection/CachingClassInspectorTest.php
@@ -29,6 +29,7 @@ class CachingClassInspectorTest extends TestCase
         $serviceCache = $this->prophesize(ServiceCacheInterface::class);
         $serviceCache->set(Argument::cetera())->will(function ($arguments) use ($serviceCache) {
             $serviceCache->get($arguments[0])->willReturn($arguments[1]);
+            $serviceCache->has($arguments[0])->willReturn(true);
         });
         $this->serviceCache = $serviceCache;
         $this->classInspector = $this->prophesize(ClassInspector::class);
@@ -58,6 +59,7 @@ class CachingClassInspectorTest extends TestCase
     public function testWarmCacheUsesOptimizedPathForConstructor(): void
     {
         $signature = [['name' => 'dependency', 'type' => 'SomeClass']];
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->classInspector->getCallableConstructorSignature(DummyDependency::class)
             ->willReturn($signature);
 
@@ -68,9 +70,25 @@ class CachingClassInspectorTest extends TestCase
         $this->classInspector->getMethodSignature(Argument::cetera())->shouldNotHaveBeenCalled();
     }
 
+    public function testWarmCachePopulatesServiceCacheForConstructor(): void
+    {
+        $signature = [['name' => 'dependency', 'type' => 'SomeClass']];
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->classInspector->getCallableConstructorSignature(DummyDependency::class)
+            ->willReturn($signature);
+
+        $this->subject->warmCache(DummyDependency::class, '__construct');
+
+        $this->serviceCache->set(
+            "Tests\Dummy\DummyDependency::__construct::callable_signature",
+            $signature
+        )->shouldHaveBeenCalled();
+    }
+
     public function testGetCallableConstructorSignatureCachesResult(): void
     {
         $signature = [['name' => 'dependency', 'type' => 'SomeClass']];
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->classInspector->getCallableConstructorSignature(DummyDependency::class)
             ->willReturn($signature)
             ->shouldBeCalledOnce();
@@ -82,8 +100,22 @@ class CachingClassInspectorTest extends TestCase
         $this->assertEquals($signature, $result2);
     }
 
+    public function testGetCallableConstructorSignatureUsesServiceCacheOnL1Miss(): void
+    {
+        $signature = [['name' => 'dependency', 'type' => 'SomeClass']];
+        $key = "Tests\Dummy\DummyDependency::__construct::callable_signature";
+        $this->serviceCache->has($key)->willReturn(true);
+        $this->serviceCache->get($key)->willReturn($signature);
+
+        $result = $this->subject->getCallableConstructorSignature(DummyDependency::class);
+
+        $this->assertEquals($signature, $result);
+        $this->classInspector->getCallableConstructorSignature(Argument::cetera())->shouldNotHaveBeenCalled();
+    }
+
     public function testGetCallableConstructorSignatureReturnsNullForNoConstructor(): void
     {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->classInspector->getCallableConstructorSignature(DummyDependency::class)
             ->willReturn(null);
 
@@ -94,6 +126,7 @@ class CachingClassInspectorTest extends TestCase
 
     public function testGetCallableConstructorSignatureReturnsFalseForNonPublicConstructor(): void
     {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->classInspector->getCallableConstructorSignature(DummyDependency::class)
             ->willReturn(false);
 


### PR DESCRIPTION
## What

`CachingClassInspector::getCallableConstructorSignature()` was the only method that didn't use `serviceCache`. It cached results in a per-instance PHP array (`$constructorCache`) that was rebuilt every request. The `serviceCache` — which can be backed by the precomputed PHP file loaded via OPcache wasn't used for this.

This meant `service:precompute_service_cache` produced an effectively empty cache file for constructor lookups, since `warmCache($key, '__construct')` went through `getCallableConstructorSignature()` which stored results in the per-instance array only.

Now `getCallableConstructorSignature` checks `serviceCache` as an L2 cache behind the per-instance L1. Only `array` results (valid signatures) are persisted — `false` (non-public constructor) and `null` (no constructor) stay in L1 only, since those classes are resolved from the container and never `create()`d.

## Impact

Measured with Excimer CPU profiling (30 requests to a storefront product page, precomputed PHP file cache active):

| Metric | Before | After | Delta |
|--------|-------:|------:|------:|
| `ClassInspector::getReflectionClass` | 8.4 ms/req | 2.8 ms/req | **-67%** |
| Total injector self CPU | 18.1 ms/req | 12.4 ms/req | **-31%** |
| Total request CPU | 267 ms/req | 215 ms/req | **-20%** (t=-5.24) |

`service:precompute_service_cache` now writes ~4400 constructor signature entries instead of 0.