### PR TITLE
perf: Add L1 in-memory caches for classHasMethod() and methodIsPublic()

### DIFF
--- a/src/Reflection/CachingClassInspector.php
+++ b/src/Reflection/CachingClassInspector.php
@@ -14,6 +14,15 @@ class CachingClassInspector implements ClassInspectorInterface
      */
     private array $constructorCache = [];
 
+    /**
+     * @var array<string, bool>
+     */
+    private array $classHasMethodCache = [];
+
+    /**
+     * @var array<string, bool>
+     */
+    private array $methodIsPublicCache = [];
     public function __construct(
         private readonly ClassInspector $classInspector,
         private readonly ServiceCacheInterface $serviceCache,
@@ -51,6 +60,11 @@ class CachingClassInspector implements ClassInspectorInterface
      */
     public function classHasMethod(string $class, string $method): bool
     {
+        $cacheKey = "$class::$method";
+        if (array_key_exists($cacheKey, $this->classHasMethodCache)) {
+            return $this->classHasMethodCache[$cacheKey];
+        }
+
         $key = "$class::{$method}::exists";
         if ($this->serviceCache->has($key)) {
             $value = $this->serviceCache->get($key);
@@ -59,6 +73,7 @@ class CachingClassInspector implements ClassInspectorInterface
             $this->serviceCache->set($key, $value);
         }
 
+        $this->classHasMethodCache[$cacheKey] = $value;
         return $value;
     }
 
@@ -72,6 +87,11 @@ class CachingClassInspector implements ClassInspectorInterface
      */
     public function methodIsPublic(string $class, string $method): bool
     {
+        $cacheKey = "$class::$method";
+        if (array_key_exists($cacheKey, $this->methodIsPublicCache)) {
+            return $this->methodIsPublicCache[$cacheKey];
+        }
+
         $key = "$class::{$method}::is_public";
         if ($this->serviceCache->has($key)) {
             $value = $this->serviceCache->get($key);
@@ -80,6 +100,7 @@ class CachingClassInspector implements ClassInspectorInterface
             $this->serviceCache->set($key, $value);
         }
 
+        $this->methodIsPublicCache[$cacheKey] = $value;
         return $value;
     }
 

--- a/tests/Reflection/CachingClassInspectorTest.php
+++ b/tests/Reflection/CachingClassInspectorTest.php
@@ -145,6 +145,35 @@ class CachingClassInspectorTest extends TestCase
         $this->classInspector->classHasMethod(Argument::cetera())->shouldNotHaveBeenCalled();
     }
 
+    public function testClassHasMethodUsesL1CacheOnSecondCall(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->classInspector->classHasMethod(DummyDependency::class, 'isEnabled')
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+
+        $result1 = $this->subject->classHasMethod(DummyDependency::class, 'isEnabled');
+        $result2 = $this->subject->classHasMethod(DummyDependency::class, 'isEnabled');
+
+        $this->assertTrue($result1);
+        $this->assertTrue($result2);
+        $this->serviceCache->has(Argument::cetera())->shouldHaveBeenCalledOnce();
+    }
+
+    public function testClassHasMethodL1CacheReturnsFalseCorrectly(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->classInspector->classHasMethod(DummyDependency::class, 'nonExistent')
+            ->willReturn(false)
+            ->shouldBeCalledOnce();
+
+        $result1 = $this->subject->classHasMethod(DummyDependency::class, 'nonExistent');
+        $result2 = $this->subject->classHasMethod(DummyDependency::class, 'nonExistent');
+
+        $this->assertFalse($result1);
+        $this->assertFalse($result2);
+    }
+
     public function testClassHasMethodReturnsTrueForExistingMethodOnCacheMiss(): void
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
@@ -184,6 +213,21 @@ class CachingClassInspectorTest extends TestCase
         $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
 
         $this->classInspector->methodIsPublic(Argument::cetera())->shouldNotHaveBeenCalled();
+    }
+
+    public function testMethodIsPublicUsesL1CacheOnSecondCall(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->classInspector->methodIsPublic(DummyDependency::class, 'isEnabled')
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+
+        $result1 = $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
+        $result2 = $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
+
+        $this->assertTrue($result1);
+        $this->assertTrue($result2);
+        $this->serviceCache->has(Argument::cetera())->shouldHaveBeenCalledOnce();
     }
 
     public function testMethodIsPublicReturnsTrueForExistingMethodOnCacheMiss(): void


### PR DESCRIPTION
## Summary

`getMethodSignature()` and `getCallableConstructorSignature()` already have in-memory L1 caches (`$methodSignatureCache`, `$constructorCache`) that skip repeated L2 (`ServiceCache`) lookups within the same request. `classHasMethod()` and `methodIsPublic()` lacked this. Every call went straight to the L2 cache, incurring a `has()` + `get()` round trip even for values already resolved earlier in the request.

This adds `$classHasMethodCache` and `$methodIsPublicCache` arrays to `CachingClassInspector`, following the same pattern as the existing L1 caches. Uses `array_key_exists()` instead of `isset()` since the cached values are booleans (and `false` is a valid cached value).

## Testing
Added some unit tests