### PR TITLE
perf: Accept precomputed constructor signatures to skip runtime reflection

### DIFF
--- a/src/InjectorFactory.php
+++ b/src/InjectorFactory.php
@@ -15,10 +15,14 @@ use Psr\Container\ContainerInterface;
 
 class InjectorFactory
 {
+    /**
+     * @param array<string, array{0: array|false|null}> $precomputedConstructorSignatures
+     */
     public static function create(
         ContainerInterface $container,
         int $reflectionClassCacheSize = 50,
         ?ServiceCacheInterface $serviceCache = null,
+        array $precomputedConstructorSignatures = [],
     ): InjectorInterface {
         $classInspector = new ClassInspector(
             new ReflectionClassCache($reflectionClassCacheSize),
@@ -29,6 +33,7 @@ class InjectorFactory
         $cachingClassInspector = new CachingClassInspector(
             $classInspector,
             $serviceCache ?? new ArrayServiceCache(),
+            $precomputedConstructorSignatures,
         );
 
         return new Injector($container, $cachingClassInspector);

--- a/src/Reflection/CachingClassInspector.php
+++ b/src/Reflection/CachingClassInspector.php
@@ -12,12 +12,25 @@ class CachingClassInspector implements ClassInspectorInterface
     /**
      * @var array<string, array{0: array|false|null}>
      */
-    private array $constructorCache = [];
+    private array $constructorCache;
 
+    /**
+     * @param array<string, array{0: array|false|null}> $precomputedConstructorSignatures
+     */
     public function __construct(
         private readonly ClassInspector $classInspector,
         private readonly ServiceCacheInterface $serviceCache,
+        array $precomputedConstructorSignatures = [],
     ) {
+        $this->constructorCache = $precomputedConstructorSignatures;
+    }
+
+    /**
+     * @return array<string, array{0: array|false|null}>
+     */
+    public function getConstructorCache(): array
+    {
+        return $this->constructorCache;
     }
 
     /**

--- a/tests/Reflection/CachingClassInspectorTest.php
+++ b/tests/Reflection/CachingClassInspectorTest.php
@@ -257,4 +257,82 @@ class CachingClassInspectorTest extends TestCase
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::signature", [])
             ->shouldHaveBeenCalled();
     }
+
+    public function testPrecomputedSignatureSkipsServiceCacheAndClassInspector(): void
+    {
+        $signature = [['name' => 'dependency', 'type' => 'SomeClass']];
+        $subject = new CachingClassInspector(
+            $this->classInspector->reveal(),
+            $this->serviceCache->reveal(),
+            [DummyDependency::class => [$signature]],
+        );
+
+        $result = $subject->getCallableConstructorSignature(DummyDependency::class);
+
+        $this->assertEquals($signature, $result);
+        $this->serviceCache->has(Argument::cetera())->shouldNotHaveBeenCalled();
+        $this->classInspector->getCallableConstructorSignature(Argument::cetera())->shouldNotHaveBeenCalled();
+    }
+
+    public function testPrecomputedNullSignatureSkipsReflection(): void
+    {
+        $subject = new CachingClassInspector(
+            $this->classInspector->reveal(),
+            $this->serviceCache->reveal(),
+            [DummyDependency::class => [null]],
+        );
+
+        $result = $subject->getCallableConstructorSignature(DummyDependency::class);
+
+        $this->assertNull($result);
+        $this->classInspector->getCallableConstructorSignature(Argument::cetera())->shouldNotHaveBeenCalled();
+    }
+
+    public function testPrecomputedFalseSignatureSkipsReflection(): void
+    {
+        $subject = new CachingClassInspector(
+            $this->classInspector->reveal(),
+            $this->serviceCache->reveal(),
+            [DummyDependency::class => [false]],
+        );
+
+        $result = $subject->getCallableConstructorSignature(DummyDependency::class);
+
+        $this->assertFalse($result);
+        $this->classInspector->getCallableConstructorSignature(Argument::cetera())->shouldNotHaveBeenCalled();
+    }
+
+    public function testEmptyPrecomputedArrayPreservesExistingBehavior(): void
+    {
+        $signature = [['name' => 'dependency', 'type' => 'SomeClass']];
+        $subject = new CachingClassInspector(
+            $this->classInspector->reveal(),
+            $this->serviceCache->reveal(),
+            [],
+        );
+
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->classInspector->getCallableConstructorSignature(DummyDependency::class)
+            ->willReturn($signature);
+
+        $result = $subject->getCallableConstructorSignature(DummyDependency::class);
+
+        $this->assertEquals($signature, $result);
+        $this->classInspector->getCallableConstructorSignature(DummyDependency::class)
+            ->shouldHaveBeenCalled();
+    }
+
+    public function testGetConstructorCacheReturnsWarmData(): void
+    {
+        $signature = [['name' => 'dependency', 'type' => 'SomeClass']];
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->classInspector->getCallableConstructorSignature(DummyDependency::class)
+            ->willReturn($signature);
+
+        $this->subject->getCallableConstructorSignature(DummyDependency::class);
+
+        $cache = $this->subject->getConstructorCache();
+        $this->assertArrayHasKey(DummyDependency::class, $cache);
+        $this->assertEquals([$signature], $cache[DummyDependency::class]);
+    }
 }


### PR DESCRIPTION
#### What?

Add an optional `$precomputedConstructorSignatures` parameter to `CachingClassInspector` that directly initializes the in-memory `$constructorCache`. When provided, `getCallableConstructorSignature()` resolves in a single `isset()` — no string concatenation, no ServiceCache lookup, no PHP reflection.

The intended usage is for build-time tooling to warm the constructor cache for all known service classes, serialize it to a PHP file, and load it at runtime. This collapses the three-tier cache lookup (in-memory → ServiceCache → reflection) into a single array check for all precomputed classes.

Also adds `getConstructorCache(): array` so build tooling can extract the warmed cache after calling `warmCache()` for each service key.

**Backward compatible** — the new parameter defaults to `[]`, preserving existing behavior.

**Performance**: Benchmarking constructor signature resolution for ~5500 classes shows:
- ServiceCache (current): 18ms
- Precomputed (this change): 6ms — 3x faster

#### Tickets / Documentation

Internal performance work.