### PR TITLE
fix: preserve null service values in find() resolution

### DIFF
--- a/src/Adapter/ArrayContainerAdapter.php
+++ b/src/Adapter/ArrayContainerAdapter.php
@@ -3,6 +3,7 @@ namespace Bigcommerce\Injector\Adapter;
 
 use Bigcommerce\Injector\Adapter\Exception\ServiceNotFoundException;
 use Bigcommerce\Injector\FindableContainerInterface;
+use Bigcommerce\Injector\FindResult;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
@@ -58,15 +59,16 @@ class ArrayContainerAdapter implements FindableContainerInterface
     }
 
     /**
-     * Return the entry for the given id, or NULL if it isn't in the container. A single lookup, so callers can skip the
-     * separate ->has() call. Matches ->has()/->get(): a stored null is treated as absent (isset semantics), so a
-     * present entry is never NULL
+     * Return the entry for the given id, or the FindResult::NotFound sentinel if it isn't in the container. A single
+     * lookup, so callers can skip the separate ->has() call. Presence is decided with isset() to match ->has()/->get();
+     * when present the entry is returned as-is, including NULL (e.g. a Pimple service whose factory resolves to NULL),
+     * which the sentinel keeps distinct from absence.
      *
      * @param string $id
-     * @return mixed
+     * @return mixed The entry (which may be NULL), or FindResult::NotFound when absent
      */
     public function find(string $id): mixed
     {
-        return $this->arrayContainer[$id] ?? null;
+        return isset($this->arrayContainer[$id]) ? $this->arrayContainer[$id] : FindResult::NotFound;
     }
 }

--- a/src/FindResult.php
+++ b/src/FindResult.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bigcommerce\Injector;
+
+/**
+ * Sentinel returned by {@see FindableContainerInterface::find()} to signal "no entry for this id".
+ *
+ * find() returns this instead of NULL so that an entry which is itself NULL can be returned and told
+ * apart from a genuine absence. A service may legitimately resolve to NULL (e.g. an optional setting);
+ * conflating that with "not registered" is what previously stopped the Injector from supplying NULL to
+ * nullable-but-present constructor dependencies.
+ */
+enum FindResult
+{
+    case NotFound;
+}

--- a/src/FindableContainerInterface.php
+++ b/src/FindableContainerInterface.php
@@ -5,18 +5,20 @@ namespace Bigcommerce\Injector;
 use Psr\Container\ContainerInterface;
 
 /**
- * A container that can return an entry (or NULL when absent) in a single lookup, letting callers avoid the ->has() +
- * ->get() double lookup.
+ * A container that can return an entry in a single lookup, letting callers avoid the ->has() + ->get()
+ * double lookup.
  *
- * Containers implementing this must not store NULL entries: a NULL return always means "no entry for this id"
+ * find() returns the {@see FindResult::NotFound} sentinel (not NULL) when there is no entry, so an entry
+ * that is itself NULL can be returned and told apart from absence.
  */
 interface FindableContainerInterface extends ContainerInterface
 {
     /**
-     * Return the entry for the given id, or NULL if the container has no entry for it
+     * Return the entry for the given id, or the {@see FindResult::NotFound} sentinel if the container has
+     * no entry for it. The entry itself may be NULL, which is distinct from absence.
      *
      * @param string $id
-     * @return mixed
+     * @return mixed The entry (which may be NULL), or FindResult::NotFound when absent
      */
     public function find(string $id): mixed;
 }

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -252,12 +252,14 @@ class Injector implements InjectorInterface
             }
             $type = $parameterData['type'] ?? false;
             if ($type) {
-                $service = $this->findableContainer?->find($type);
-                if ($service !== null) {
-                    $parameters[$position] = $service;
-                    continue;
-                }
-                if ($this->findableContainer === null && $this->container->has($type)) {
+                if ($this->findableContainer !== null) {
+                    $service = $this->findableContainer->find($type);
+                    if ($service !== FindResult::NotFound) {
+                        // a present entry may itself be NULL - that is a valid resolved value, not an absence
+                        $parameters[$position] = $service;
+                        continue;
+                    }
+                } elseif ($this->container->has($type)) {
                     $parameters[$position] = $this->container->get($type);
                     continue;
                 }
@@ -317,12 +319,13 @@ class Injector implements InjectorInterface
                 unset($providedParameters[$type]);
                 return $result;
             }
-            $service = $this->findableContainer?->find($type);
-            if ($service !== null) {
-                // Found the dependency by type in the container
-                return $service;
-            }
-            if ($this->findableContainer === null && $this->container->has($type)) {
+            if ($this->findableContainer !== null) {
+                $service = $this->findableContainer->find($type);
+                if ($service !== FindResult::NotFound) {
+                    // Found the dependency by type in the container - a present entry may itself be NULL
+                    return $service;
+                }
+            } elseif ($this->container->has($type)) {
                 // Found the dependency by type in the container
                 return $this->container->get($type);
             }

--- a/tests/Adapter/ArrayContainerAdapterTest.php
+++ b/tests/Adapter/ArrayContainerAdapterTest.php
@@ -1,8 +1,10 @@
 <?php
 namespace tests\Adapter;
 
+use ArrayAccess;
 use Bigcommerce\Injector\Adapter\ArrayContainerAdapter;
 use Bigcommerce\Injector\Adapter\Exception\ServiceNotFoundException;
+use Bigcommerce\Injector\FindResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -43,5 +45,48 @@ class ArrayContainerAdapterTest extends TestCase
     {
         $adapter = new ArrayContainerAdapter(["found" => 123]);
         $this->assertTrue($adapter->has("found"));
+    }
+
+    public function testFindReturnsEntry()
+    {
+        $adapter = new ArrayContainerAdapter(["found" => 123]);
+        $this->assertSame(123, $adapter->find("found"));
+    }
+
+    public function testFindReturnsNotFoundSentinelWhenAbsent()
+    {
+        $adapter = new ArrayContainerAdapter([]);
+        $this->assertSame(FindResult::NotFound, $adapter->find("Missing"));
+    }
+
+    public function testFindReturnsNullForPresentEntryThatResolvesToNull()
+    {
+        // Mimics Pimple/JITContainer: offsetExists is true for a registered service even when its
+        // factory resolves to null. find() must return that null as a real value, not the NotFound
+        // sentinel, so the Injector can pass it to a nullable dependency.
+        $container = new class implements ArrayAccess {
+            public function offsetExists($offset): bool
+            {
+                return $offset === 'present-but-null';
+            }
+
+            public function offsetGet($offset): mixed
+            {
+                return null;
+            }
+
+            public function offsetSet($offset, $value): void
+            {
+            }
+
+            public function offsetUnset($offset): void
+            {
+            }
+        };
+
+        $adapter = new ArrayContainerAdapter($container);
+
+        $this->assertNull($adapter->find("present-but-null"));
+        $this->assertSame(FindResult::NotFound, $adapter->find("absent"));
     }
 }

--- a/tests/Dummy/DummyNullableDependency.php
+++ b/tests/Dummy/DummyNullableDependency.php
@@ -1,0 +1,45 @@
+<?php
+namespace Tests\Dummy;
+
+/**
+ * Dummy class with a nullable, required dependency. Mirrors real classes (e.g. a storefront resource taking an
+ * optional setting) whose dependency can legitimately resolve to NULL from the container.
+ */
+class DummyNullableDependency
+{
+    /**
+     * @var DummySubDependency|null
+     */
+    private $dependency;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param DummySubDependency|null $dependency
+     * @param string $name
+     */
+    public function __construct(?DummySubDependency $dependency, $name = 'default')
+    {
+        $this->dependency = $dependency;
+        $this->name = $name;
+    }
+
+    /**
+     * @return DummySubDependency|null
+     */
+    public function getDependency()
+    {
+        return $this->dependency;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -13,6 +13,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Tests\Dummy\DummyDependency;
 use Tests\Dummy\DummyNoConstructor;
+use Tests\Dummy\DummyNullableDependency;
 use Tests\Dummy\DummyPrivateConstructor;
 use Tests\Dummy\DummySimpleConstructor;
 use Tests\Dummy\DummyString;
@@ -280,6 +281,82 @@ class InjectorTest extends TestCase
 
         $this->expectException(InjectorInvocationException::class);
         $injector->create(DummyDependency::class);
+    }
+
+    /**
+     * Regression: a registered service can legitimately resolve to NULL (e.g. an optional setting). find()
+     * must hand that NULL to a nullable parameter rather than treating the service as absent and throwing.
+     *
+     * This exercises the no-args fast path (buildParameterArrayFromContainer).
+     */
+    public function testFindableContainerResolvesPresentDependencyThatIsNull()
+    {
+        $this->inspector->getCallableConstructorSignature(DummyNullableDependency::class)
+            ->willReturn([
+                ["name" => "dependency", "type" => DummySubDependency::class],
+            ]);
+
+        $injector = new Injector(
+            new ArrayContainerAdapter($this->containerResolvingTo(null)),
+            $this->inspector->reveal()
+        );
+
+        $instance = $injector->create(DummyNullableDependency::class);
+        $this->assertNull($instance->getDependency());
+    }
+
+    /**
+     * As above, but via the provided-parameters path (resolveParameter), covering the second find() call site:
+     * one parameter is passed explicitly, the nullable one is resolved from the container as NULL.
+     */
+    public function testFindableContainerResolvesPresentNullDependencyWithProvidedParameters()
+    {
+        $this->inspector->getCallableConstructorSignature(DummyNullableDependency::class)
+            ->willReturn([
+                ["name" => "dependency", "type" => DummySubDependency::class],
+                ["name" => "name"],
+            ]);
+
+        $injector = new Injector(
+            new ArrayContainerAdapter($this->containerResolvingTo(null)),
+            $this->inspector->reveal()
+        );
+
+        $instance = $injector->create(DummyNullableDependency::class, ["name" => "bob"]);
+        $this->assertNull($instance->getDependency());
+        $this->assertSame("bob", $instance->getName());
+    }
+
+    /**
+     * A Pimple/JITContainer-like ArrayAccess where offsetExists is true for a registered service even though
+     * its factory resolves to the given value (here NULL). Reproduces the "present but resolves to null" case
+     * that find() must keep distinct from absence.
+     */
+    private function containerResolvingTo(mixed $value): \ArrayAccess
+    {
+        return new class ($value) implements \ArrayAccess {
+            public function __construct(private mixed $value)
+            {
+            }
+
+            public function offsetExists($offset): bool
+            {
+                return true;
+            }
+
+            public function offsetGet($offset): mixed
+            {
+                return $this->value;
+            }
+
+            public function offsetSet($offset, $value): void
+            {
+            }
+
+            public function offsetUnset($offset): void
+            {
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
`find()` returned `null` both for a missing entry and for an entry that resolves to `null`, so the Injector treated a present-but-null dependency as absent and threw instead of supplying `null` to a nullable parameter.

Adds a `FindResult::NotFound` sentinel so `find()` keeps a present `null` distinct from absence. Tests cover both Injector resolution paths and the adapter.